### PR TITLE
add shinydashboard to list of packages to prompt to install

### DIFF
--- a/app.R
+++ b/app.R
@@ -1,4 +1,4 @@
-required_packages <- c("shiny", "tidyverse", "googlesheets", "DT", "jsonlite", "purrr")
+required_packages <- c("shiny", "tidyverse", "googlesheets", "DT", "jsonlite", "purrr", "shinydashboard")
 missing_packages <- !(required_packages %in% rownames(installed.packages()))
 if(any(missing_packages)){
   stop(paste0('Some additional packages are necessary to run this app. Please install them using this command:


### PR DESCRIPTION
Just tried to run this locally with `shiny::runGitHub("cooee", "useR-2018")` and found that I needed shinydashboard. Maybe others will too?